### PR TITLE
Changed composer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,8 @@ Install
 
 Via Composer
 
-```json
-{
-    "require": {
-        "league/phpunit-coverage-listener": "~1.1"
-    }
-}
+```bash
+composer require league/phpunit-coverage-listener
 ```
 
 Basic Usage


### PR DESCRIPTION
Using the command-line composer require is the preferred way to install packages now.
